### PR TITLE
Add origin_app_factory to Flask plugin, add 'table_schema' to default…

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -78,6 +78,7 @@ class VersioningManager(object):
         self.options = {
             'versioning': True,
             'base_classes': None,
+            'table_schema': None,
             'table_name': '%s_version',
             'exclude': [],
             'include': [],


### PR DESCRIPTION
… manager options

Description
-----------
- Flask plugin now grabs the originating application's app name and saves it with
  the provided transaction class
- Add 'table_schema' to default manager options to avoid KeyErrors when grabbing
  individual class schema config

Related JIRA Issues
-------------------

Related Pull Requests
---------------------

Migrations
----------

Extra Deployment Steps
----------------------

Testing Steps
-------------