### PR TITLE
Don't raise when a uow can't be found

### DIFF
--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -430,7 +430,7 @@ class VersioningManager(object):
                         uow = self.unit_of_work(conn.session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
-                    raise
+                    return
         uow.pending_statements.append(stmt)
 
     def track_cloned_connections(self, c, opt):


### PR DESCRIPTION
This was causing _every_ test to break. Making this more like the old code fixes the issue:

https://github.com/trialspark/sqlalchemy-continuum/blob/a636fe0bd6735a4383c582802927143b6089cfbe/sqlalchemy_continuum/manager.py#L386-L392