### PR TITLE
Add support for custom table_name parameter in sync_trigger

### DIFF
--- a/docs/native_versioning.rst
+++ b/docs/native_versioning.rst
@@ -33,13 +33,13 @@ When making schema migrations (for example adding new columns to version tables)
 
 You also may have a custom option set on the versioning manager called `table_name`, which tells the manager what the versioned table should be called, given a parent table name.  The default is `%s_version`.
 
-If you have this set to something custom, you should instead run
+If you have this set to something custom on the versioning manager, you can pass the manager into sync_trigger.
 
 ::
 
     from sqlalchemy_continuum import versioning_manager # or import your custom one, if you have one
     sync_trigger(conn,
                  'article_version',
-                 version_table_name_format=versioning_manager.option('table_name'))
+                 versioning_manager=versioning_manager)
 
 

--- a/docs/native_versioning.rst
+++ b/docs/native_versioning.rst
@@ -30,3 +30,16 @@ When making schema migrations (for example adding new columns to version tables)
 
 
     sync_trigger(conn, 'article_version')
+
+You also may have a custom option set on the versioning manager called `table_name`, which tells the manager what the versioned table should be called, given a parent table name.  The default is `%s_version`.
+
+If you have this set to something custom, you should instead run
+
+::
+
+    from sqlalchemy_continuum import versioning_manager # or import your custom one, if you have one
+    sync_trigger(conn,
+                 'article_version',
+                 version_table_name_format=versioning_manager.option('table_name'))
+
+

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -20,7 +20,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.12'
+__version__ = '1.4.0'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -462,9 +462,10 @@ def reverse_table_name_format(version_table_name_format):
     """
     return '^' + version_table_name_format.replace('%s', '(.*)') + '$'
 
+DEFAULT_VERSION_TABLE_NAME_FORMAT = '%s_version'
 def sync_trigger(conn,
                  table_name,
-                 version_table_name_format='%s_version'):
+                 versioning_manager=None):
     """
     Synchronizes versioning trigger for given table with given connection.
 
@@ -476,10 +477,12 @@ def sync_trigger(conn,
 
     :param conn: SQLAlchemy connection object
     :param table_name: Name of the table to synchronize versioning trigger for
-    :param version_table_name_format: The custom table_name option that you may have set on the versioning manager
+    :param versioning_manager: (Optional) the versioning manager
 
     .. versionadded: 1.1.0
     """
+    custom_version_table_name_format = versioning_manager.option('table_name') if versioning_manager else None
+    version_table_name_format = custom_version_table_name_format or DEFAULT_VERSION_TABLE_NAME_FORMAT
     parent_table_name_regex = reverse_table_name_format(version_table_name_format)
     
     meta = sa.MetaData()
@@ -517,7 +520,7 @@ def create_trigger(
     table,
     transaction_column_name='transaction_id',
     operation_type_column_name='operation_type',
-    version_table_name_format='%s_version',
+    version_table_name_format=DEFAULT_VERSION_TABLE_NAME_FORMAT,
     excluded_columns=None,
     use_property_mod_tracking=True,
     end_transaction_column_name=None,

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -97,6 +97,9 @@ class VersioningManager(object):
             self.plugins = plugins
         self.options.update(options)
 
+        if self.options['table_name'].count('%s') > 1:
+            raise ValueError('The table_name option must be set with only a single `%%s`. found %s' % self.options['table_name'])
+
     @property
     def plugins(self):
         return self._plugins


### PR DESCRIPTION
sync_trigger drops an existing trigger and re-creates it using new pertinent columns.

However, it does not take into account custom versioned table naming schemes.  It assumes that all tables have a version table that ends in `_version`.

This PR allows the caller of sync_trigger to send the versioning manager's `table_name` option to the function, allowing support for custom table_name options with native versioning.