### PR TITLE
A couple fixes for sync_trigger, decoupling creation of triggers optionally

### DIFF
--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -20,7 +20,7 @@ from .utils import (
 )
 
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -574,14 +574,17 @@ def create_trigger(
 
 
 def drop_trigger(conn, table_name, table_schema=None):
-    compound_name = table_name
+    compound_procedure_name = table_name
+    schema = ''
     if table_schema:
-        compound_name = '%s_%s' % (table_schema, table_name)
+        compound_procedure_name = '%s_%s' % (table_schema, table_name)
+        schema = table_schema + '.'
 
     conn.execute(
-        'DROP TRIGGER IF EXISTS %s_trigger ON "%s"' % (
+        'DROP TRIGGER IF EXISTS %s_trigger ON %s"%s"' % (
             table_name,
+            schema,
             table_name
         )
     )
-    conn.execute('DROP FUNCTION IF EXISTS %s_audit()' % compound_name)
+    conn.execute('DROP FUNCTION IF EXISTS %s_audit()' % compound_procedure_name)

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -456,6 +456,9 @@ class TransactionTriggerSQL(object):
 
 
 def create_versioning_trigger_listeners(manager, cls):
+    if not manager.options['create_trigger_listeners']:
+        return
+    
     compound_trigger_name = cls.__table__.name
     if cls.__table__.schema:
        compound_trigger_name = '%s_%s' % (cls.__table__.schema, compound_trigger_name) 

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -487,7 +487,8 @@ def reverse_table_name_format(version_table_name_format):
 DEFAULT_VERSION_TABLE_NAME_FORMAT = '%s_version'
 def sync_trigger(conn,
                  table_name,
-                 versioning_manager):
+                 versioning_manager,
+                 schema=None):
     """
     Synchronizes versioning trigger for given table with given connection.
 
@@ -507,7 +508,7 @@ def sync_trigger(conn,
     version_table_name_format = custom_version_table_name_format or DEFAULT_VERSION_TABLE_NAME_FORMAT
     parent_table_name_regex = reverse_table_name_format(version_table_name_format)
     
-    meta = sa.MetaData()
+    meta = sa.MetaData(schema=schema)
     version_table = sa.Table(
         table_name,
         meta,

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -297,6 +297,7 @@ class DeleteUpsertSQL(UpsertSQL):
             '"{name}" = OLD."{name}"'.format(name=c.name)
             for c in self.columns
         ]
+        validity_strategy_columns = []
         if self.update_validity_for_tables:
             validity_strategy_columns = ['{0} = NULL'.format(self.end_transaction_column_name)]
         return parent_columns + validity_strategy_columns + ['%s = 2' % self.operation_type_column_name]

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -85,6 +85,7 @@ class VersioningManager(object):
             'exclude': [],
             'include': [],
             'native_versioning': False,
+            'create_trigger_listeners': True,
             'create_models': True,
             'create_tables': True,
             'transaction_column_name': 'transaction_id',

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -172,6 +172,6 @@ class TransactionFactory(ModelFactory):
                     )
                 )
 
-        if manager.options['native_versioning']:
+        if manager.options['native_versioning'] and manager.options['create_trigger_listeners']:
             create_triggers(Transaction)
         return Transaction


### PR DESCRIPTION
A few fixes in this PR:

- sync_trigger was updated to support custom version table naming schemes, BUT it was not updated to support schemas.  This PR fixes that.
- Added a config setting called `create_trigger_listeners`.

`create_trigger_listeners` defaults to `True` (to maintain parity with how continuum in native mode used to behave).  When turned to False, no triggers will be created when make_versioned is called.  This allows decoupling of the trigger creation step from the make_versioned step (i.e. server startup).  However it should be noted that create_trigger_listeners could feasibly remain True, specifically in the case that you are creating a database with the intention of destroying it later (i.e. testing!)