### PR TITLE
[ZEBRA-1139] Merge OG sqlalchemy-continuum updates into our version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: "Test"
+
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+  schedule:
+    - cron: '40 1 * * 3'
+
+jobs:
+  test:
+    name: test-python${{ matrix.python-version }}-sa${{ matrix.sqlalchemy-version }}-${{ matrix.db-engine }}
+    strategy:
+      matrix:
+        python-version:
+#          - "2.7"
+#          - "3.4"
+#          - "3.5"
+#          - "3.6"
+#          - "3.7"
+          - "3.8"
+#          - "3.9"
+#          - "3.10"
+#          - "pypy-3.7"
+        sqlalchemy-version:
+          - "<1.4"
+          - ">=1.4"
+        db-engine:
+          - "sqlite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install sqlalchemy
+        run: pip3 install 'sqlalchemy${{ matrix.sqlalchemy-version }}'
+      - name: Build
+        run: pip3 install -e '.[test]'
+      - name: Run tests
+        run: DB=${{ matrix.db-engine }} pytest
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '40 1 * * 3'
 
+
 jobs:
   test:
     name: test-python${{ matrix.python-version }}-sa${{ matrix.sqlalchemy-version }}-${{ matrix.db-engine }}
@@ -29,8 +30,36 @@ jobs:
           - "<1.4"
           - ">=1.4"
         db-engine:
-          - "sqlite"
+          - sqlite
+          - postgres
+          - postgres-native
+          - mysql
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_DATABASE: sqlalchemy_continuum_test
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 5s
+          --health-timeout 2s
+          --health-retries 3
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sqlalchemy_continuum_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 2s
+          --health-retries 3
     steps:
       - uses: actions/checkout@v1
       - name: Install sqlalchemy
@@ -38,5 +67,7 @@ jobs:
       - name: Build
         run: pip3 install -e '.[test]'
       - name: Run tests
-        run: DB=${{ matrix.db-engine }} pytest
+        run: pytest
+        env:
+          DB: ${{ matrix.db-engine }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# mypy
+.mypy_cache/
+
+# Unit test / coverage reports
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 addons:
   postgresql: 9.3
 
+dist: xenial
+sudo: true
+
 env:
   - DB=mysql
   - DB=postgres
@@ -18,6 +21,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 install:
   - pip install -e  ".[test]"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-addons:
-  postgresql: 9.3
-
 services:
   - mysql
+  - postgresql
 
 dist: xenial
 sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 addons:
   postgresql: 9.3
 
+services:
+  - mysql
+
 dist: xenial
 sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_script:
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
+  - 3.6
 install:
   - pip install -e  ".[test]"
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.3 (2017-11-05)
+^^^^^^^^^^^^^^^^^^
+
+- Fixed changeset when updating object in same transaction as inserting it (#141, courtesy of oinopion)
+
+
 1.3.2 (2017-10-12)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.2 (2017-10-12)
+^^^^^^^^^^^^^^^^^^
+
+- Fixed multiple schema handling (#132, courtesy of vault)
+
+
 1.3.1 (2017-06-28)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.12 (2022-01-18)
+^^^^^^^^^^^^^^^^^^^
+
+- Support SA 1.4
+
 1.3.11 (2020-05-24)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.7 (2019-01-13)
+^^^^^^^^^^^^^^^^^^
+
+Fix trigger creation during alembic migrations (#209, courtesy of lyndsysimon)
+
+
 1.3.6 (2018-07-30)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.11 (2020-05-24)
+^^^^^^^^^^^^^^^^^^^
+
+- Made ModelBuilder create column aliases in version models (#246, courtesy of killthekitten)
+
+
 1.3.10 (2020-05-10)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.8 (2019-02-27)
+^^^^^^^^^^^^^^^^^^
+
+- Fixed revert to ignore non-columns (#197, courtesy of mauler)
+
+
 1.3.7 (2019-01-13)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.9 (2019-03-18)
+^^^^^^^^^^^^^^^^^^
+
+- Added SA 1.3 support
+
+
 1.3.8 (2019-02-27)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,11 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
-1.3.9 (2019-03-18)
+1.3.9 (2019-03-19)
 ^^^^^^^^^^^^^^^^^^
 
 - Added SA 1.3 support
+- Reverted trigger creation from 1.3.7
 
 
 1.3.8 (2019-02-27)
@@ -19,7 +20,7 @@ Here you can see the full list of changes between each SQLAlchemy-Continuum rele
 1.3.7 (2019-01-13)
 ^^^^^^^^^^^^^^^^^^
 
-Fix trigger creation during alembic migrations (#209, courtesy of lyndsysimon)
+- Fix trigger creation during alembic migrations (#209, courtesy of lyndsysimon)
 
 
 1.3.6 (2018-07-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.5 (2018-06-03)
+^^^^^^^^^^^^^^^^^^
+
+- Track cloned connections (#167, courtesy of netcriptus)
+
+
 1.3.4 (2018-03-07)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Here you can see the full list of changes between each SQLAlchemy-Continuum rele
 ^^^^^^^^^^^^^^^^^^^
 
 - Added explicit "pseudo-backref" relationships for version/parent (#240, courtesy of lgedgar)
+- Fixed m2m Bug when an unrelated change is made to a model (#242, courtesy of Andrew-Dickinson)
 
 
 1.3.9 (2019-03-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.4 (2018-03-07)
+^^^^^^^^^^^^^^^^^^
+
+- Exclude many-to-many properties from versioning if they are added in exclude parameter (#169, courtesy of fuhrysteve)
+
+
 1.3.3 (2017-11-05)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.10 (2020-05-10)
+^^^^^^^^^^^^^^^^^^^
+
+- Added explicit "pseudo-backref" relationships for version/parent (#240, courtesy of lgedgar)
+
+
 1.3.9 (2019-03-19)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 Here you can see the full list of changes between each SQLAlchemy-Continuum release.
 
 
+1.3.6 (2018-07-30)
+^^^^^^^^^^^^^^^^^^
+
+- Fixed ResourceClosedErrors from connections leaking when using an external transaction (#196, courtesy of vault)
+
+
 1.3.5 (2018-06-03)
 ^^^^^^^^^^^^^^^^^^
 

--- a/LICENSE
+++ b/LICENSE
@@ -12,8 +12,9 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* The names of the contributors may not be used to endorse or promote products
-  derived from this software without specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ In order to make your models versioned you need two things:
     from sqlalchemy_continuum import make_versioned
 
 
-    make_versioned()
+    make_versioned(user_cls=None)
 
 
     class Article(Base):

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,39 @@ In order to make your models versioned you need two things:
     article.name
     # u'Some article'
 
+For completeness, below is a working example.
+
+.. code-block:: python
+
+    from sqlalchemy_continuum import make_versioned
+    from sqlalchemy import Column, Integer, Unicode, UnicodeText, create_engine
+    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import create_session, configure_mappers
+
+    make_versioned(user_cls=None)
+
+    Base = declarative_base()
+    class Article(Base):
+        __versioned__ = {}
+        __tablename__ = 'article'
+        id = Column(Integer, primary_key=True, autoincrement=True)
+        name = Column(Unicode(255))
+        content = Column(UnicodeText)
+
+    configure_mappers()
+    engine = create_engine('sqlite://')
+    Base.metadata.create_all(engine)
+    session = create_session(bind=engine, autocommit=False)
+
+    article = Article(name=u'Some article', content=u'Some content')
+    session.add(article)
+    session.commit()
+    article.versions[0].name
+    article.name = u'Updated name'
+    session.commit()
+    article.versions[1].name
+    article.versions[0].revert()
+    article.name
 
 Resources
 ---------

--- a/README.rst
+++ b/README.rst
@@ -119,8 +119,8 @@ Resources
 .. image:: http://i.imgur.com/UFaRx.gif
 
 
-.. |Build Status| image:: https://travis-ci.org/kvesteri/sqlalchemy-continuum.png?branch=master
-   :target: https://travis-ci.org/kvesteri/sqlalchemy-continuum
+.. |Build Status| image:: https://github.com/kvesteri/sqlalchemy-continuum/workflows/Test/badge.svg
+   :target: https://github.com/kvesteri/sqlalchemy-continuum/actions?query=workflow%3ATest
 .. |Version Status| image:: https://img.shields.io/pypi/v/SQLAlchemy-Continuum.png
    :target: https://pypi.python.org/pypi/SQLAlchemy-Continuum/
 .. |Downloads| image:: https://img.shields.io/pypi/dm/SQLAlchemy-Continuum.png

--- a/README.rst
+++ b/README.rst
@@ -53,26 +53,26 @@ In order to make your models versioned you need two things:
         content = sa.Column(sa.UnicodeText)
 
 
-    article = Article(name=u'Some article', content=u'Some content')
+    article = Article(name='Some article', content='Some content')
     session.add(article)
     session.commit()
 
     # article has now one version stored in database
     article.versions[0].name
-    # u'Some article'
+    # 'Some article'
 
-    article.name = u'Updated name'
+    article.name = 'Updated name'
     session.commit()
 
     article.versions[1].name
-    # u'Updated name'
+    # 'Updated name'
 
 
     # lets revert back to first version
     article.versions[0].revert()
 
     article.name
-    # u'Some article'
+    # 'Some article'
 
 
 Resources

--- a/benchmark.py
+++ b/benchmark.py
@@ -50,7 +50,7 @@ def test_versioning(
 
     make_versioned(options=options)
 
-    dns = 'postgres://postgres@localhost/sqlalchemy_continuum_test'
+    dns = 'postgresql://postgres:postgres@localhost/sqlalchemy_continuum_test'
     versioning_manager.plugins = plugins
     versioning_manager.transaction_cls = transaction_cls
     versioning_manager.user_cls = user_cls

--- a/docs/alembic.rst
+++ b/docs/alembic.rst
@@ -1,6 +1,11 @@
 Alembic migrations
 ==================
 
-Each time you make changes to database structure you should also change the associated history tables. When you make changes to your models SQLAlchemy-Continuum automatically alters the history model definitions, hence you can use `alembic revision --autogenerate` just like before. You just need to make sure `make_versioned` function gets called before alembic gathers all your models.
+Each time you make changes to database structure you should also change the associated history tables. When you make changes to your models SQLAlchemy-Continuum automatically alters the history model definitions, hence you can use `alembic revision --autogenerate` just like before. You just need to make sure `make_versioned` function gets called before alembic gathers all your models and `configure_mappers` is called afterwards.
 
 Pay close attention when dropping or moving data from parent tables and reflecting these changes to history tables.
+
+Troubleshooting
+###############
+
+If alembic didn't detect any changes or generates reversed migration (tries to remove `*_version` tables from database instead of creating), make sure that `configure_mappers` was called by alembic command.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,7 @@ Introduction
 Why?
 ^^^^
 
-SQLAlchemy already has versioning extension. This extension however is very limited. It does not support versioning entire transactions.
+SQLAlchemy already has a versioning extension. This extension however is very limited. It does not support versioning entire transactions.
 
 Hibernate for Java has Envers, which had nice features but lacks a nice API. Ruby on Rails has papertrail_, which has very nice API but lacks the efficiency and feature set of Envers.
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,7 @@ Introduction
 Why?
 ^^^^
 
-SQLAlchemy already has a versioning extension. This extension however is very limited. It does not support versioning entire transactions.
+SQLAlchemy [already has a versioning extension](https://docs.sqlalchemy.org/en/13/orm/examples.html#module-examples.versioned_history). This extension however is very limited. It does not support versioning entire transactions.
 
 Hibernate for Java has Envers, which had nice features but lacks a nice API. Ruby on Rails has papertrail_, which has very nice API but lacks the efficiency and feature set of Envers.
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,7 @@ Introduction
 Why?
 ^^^^
 
-SQLAlchemy [already has a versioning extension](https://docs.sqlalchemy.org/en/13/orm/examples.html#module-examples.versioned_history). This extension however is very limited. It does not support versioning entire transactions.
+SQLAlchemy `already has a versioning extension <https://docs.sqlalchemy.org/en/13/orm/examples.html#module-examples.versioned_history>`_. This extension however is very limited. It does not support versioning entire transactions.
 
 Hibernate for Java has Envers, which had nice features but lacks a nice API. Ruby on Rails has papertrail_, which has very nice API but lacks the efficiency and feature set of Envers.
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -54,7 +54,7 @@ In order to make your models versioned you need two things:
     from sqlalchemy_continuum import make_versioned
 
 
-    make_versioned()
+    make_versioned(user_cls=None)
 
 
     class Article(Base):

--- a/docs/native_versioning.rst
+++ b/docs/native_versioning.rst
@@ -30,3 +30,9 @@ When making schema migrations (for example adding new columns to version tables)
 
 
     sync_trigger(conn, 'article_version')
+
+If you don't use `PropertyModTrackerPlugin`, then you have to disable it:
+
+::
+
+    sync_trigger(conn, 'article_version', use_property_mod_tracking=False)

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -7,7 +7,7 @@ Using plugins
 
 ::
 
-    from sqlalchemy.continuum.plugins import PropertyModTrackerPlugin
+    from sqlalchemy_continuum.plugins import PropertyModTrackerPlugin
 
 
     versioning_manager.plugins.append(PropertyModTrackerPlugin())

--- a/docs/version_objects.rst
+++ b/docs/version_objects.rst
@@ -102,7 +102,7 @@ you can easily check the changeset of given object in current transaction.
 
     article = Article(name=u'Some article')
     changeset(article)
-    # {'name': [u'Some article', None]}
+    # {'name': [None, u'Some article']}
 
 
 Version relationships

--- a/setup.py
+++ b/setup.py
@@ -77,9 +77,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         'pytest>=2.3.5',
         'flexmock>=0.9.7',
         'psycopg2>=2.4.6',
-        'PyMySQL==0.6.1',
+        'PyMySQL>=0.8.0',
         'six>=1.4.0'
     ],
     'anyjson': ['anyjson>=0.3.3'],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ extras_require = {
         'PyMySQL>=0.8.0',
         'six>=1.4.0'
     ],
-    'anyjson': ['anyjson>=0.3.3'],
     'flask': ['Flask>=0.9'],
     'flask-login': ['Flask-Login>=0.2.9'],
     'flask-sqlalchemy': ['Flask-SQLAlchemy>=1.0'],

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
     'flask-login': ['Flask-Login>=0.2.9'],
     'flask-sqlalchemy': ['Flask-SQLAlchemy>=1.0'],
     'flexmock': ['flexmock>=0.9.7'],
-    'i18n': ['SQLAlchemy-i18n>=0.8.4'],
+    'i18n': ['SQLAlchemy-i18n>=0.8.4,!=1.1.0'],
 }
 
 

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -70,6 +70,12 @@ def make_versioned(
         manager.track_association_operations
     )
 
+    sa.event.listen(
+        sa.engine.Engine,
+        'set_connection_execution_options',
+        manager.track_cloned_connections
+    )
+
 
 def remove_versioning(
     mapper=sa.orm.mapper,
@@ -95,4 +101,10 @@ def remove_versioning(
         sa.engine.Engine,
         'before_cursor_execute',
         manager.track_association_operations
+    )
+
+    sa.event.remove(
+        sa.engine.Engine,
+        'set_connection_execution_options',
+        manager.track_cloned_connections
     )

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.4'
+__version__ = '1.3.5'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.10'
+__version__ = '1.3.11'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.9'
+__version__ = '1.3.10'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -72,6 +72,12 @@ def make_versioned(
 
     sa.event.listen(
         sa.engine.Engine,
+        'rollback',
+        manager.clear_connection
+    )
+
+    sa.event.listen(
+        sa.engine.Engine,
         'set_connection_execution_options',
         manager.track_cloned_connections
     )
@@ -101,6 +107,12 @@ def remove_versioning(
         sa.engine.Engine,
         'before_cursor_execute',
         manager.track_association_operations
+    )
+
+    sa.event.remove(
+        sa.engine.Engine,
+        'rollback',
+        manager.clear_connection
     )
 
     sa.event.remove(

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.3'
+__version__ = '1.3.4'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.5'
+__version__ = '1.3.6'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.7'
+__version__ = '1.3.8'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.8'
+__version__ = '1.3.9'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.11'
+__version__ = '1.3.12'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/__init__.py
+++ b/sqlalchemy_continuum/__init__.py
@@ -18,7 +18,7 @@ from .utils import (
 )
 
 
-__version__ = '1.3.6'
+__version__ = '1.3.7'
 
 
 versioning_manager = VersioningManager()

--- a/sqlalchemy_continuum/dialects/postgresql.py
+++ b/sqlalchemy_continuum/dialects/postgresql.py
@@ -456,7 +456,7 @@ def create_versioning_trigger_listeners(manager, cls):
     )
 
 
-def sync_trigger(conn, table_name):
+def sync_trigger(conn, table_name, **kwargs):
     """
     Synchronizes versioning trigger for given table with given connection.
 
@@ -468,6 +468,7 @@ def sync_trigger(conn, table_name):
 
     :param conn: SQLAlchemy connection object
     :param table_name: Name of the table to synchronize versioning trigger for
+    :params **kwargs: kwargs to pass to create_trigger
 
     .. versionadded: 1.1.0
     """
@@ -489,7 +490,7 @@ def sync_trigger(conn, table_name):
         set(c.name for c in version_table.c if not c.name.endswith('_mod'))
     )
     drop_trigger(conn, parent_table.name)
-    create_trigger(conn, table=parent_table, excluded_columns=excluded_columns)
+    create_trigger(conn, table=parent_table, excluded_columns=excluded_columns, **kwargs)
 
 
 def create_trigger(

--- a/sqlalchemy_continuum/factory.py
+++ b/sqlalchemy_continuum/factory.py
@@ -6,7 +6,11 @@ class ModelFactory(object):
         Create model class but only if it doesn't already exist
         in declarative model registry.
         """
-        registry = manager.declarative_base._decl_class_registry
+        Base = manager.declarative_base
+        try:
+            registry = Base.registry._class_registry
+        except AttributeError:  # SQLAlchemy < 1.4
+            registry = Base._decl_class_registry
         if self.model_name not in registry:
             return self.create_class(manager)
         return registry[self.model_name]

--- a/sqlalchemy_continuum/fetcher.py
+++ b/sqlalchemy_continuum/fetcher.py
@@ -59,7 +59,7 @@ class VersionObjectFetcher(object):
             func = sa.func.max
 
         if alias is None:
-            alias = sa.orm.aliased(obj)
+            alias = sa.orm.aliased(obj.__class__)
             table = alias.__table__
             if hasattr(alias, 'c'):
                 attrs = alias.c
@@ -117,7 +117,7 @@ class VersionObjectFetcher(object):
         Returns the query needed for fetching the index of this record relative
         to version history.
         """
-        alias = sa.orm.aliased(obj)
+        alias = sa.orm.aliased(obj.__class__)
 
         subquery = (
             sa.select([sa.func.count('1')], from_obj=[alias.__table__])

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -24,7 +24,15 @@ def tracked_operation(func):
         try:
             uow = self.units_of_work[conn]
         except KeyError:
-            uow = self.units_of_work[conn.engine]
+            try:
+                uow = self.units_of_work[conn.engine]
+            except KeyError:
+                for connection in self.units_of_work.keys():
+                    if connection.connection is conn.connection:
+                        uow = self.unit_of_work(session)
+                        break  # The ConnectionFairy is the same, this connection is a clone
+                else:
+                    raise KeyError
         return func(self, uow, target)
     return wrapper
 
@@ -357,10 +365,19 @@ class VersioningManager(object):
         if session.transaction.nested:
             return
         conn = self.session_connection_map.pop(session, None)
+        if conn is None:
+            return
+
         if conn in self.units_of_work:
             uow = self.units_of_work[conn]
             uow.reset(session)
             del self.units_of_work[conn]
+
+        for connection in dict(self.units_of_work).keys():
+            if conn.connection is connection.connection:
+                uow = self.units_of_work[connection]
+                uow.reset(session)
+                del self.units_of_work[connection]
 
     def append_association_operation(self, conn, table_name, params, op):
         """
@@ -375,8 +392,25 @@ class VersioningManager(object):
         try:
             uow = self.units_of_work[conn]
         except KeyError:
-            uow = self.units_of_work[conn.engine]
+            try:
+                uow = self.units_of_work[conn.engine]
+            except KeyError:
+                for connection in self.units_of_work.keys():
+                    if connection.connection is conn.connection:
+                        uow = self.unit_of_work(conn.session)
+                        break  # The ConnectionFairy is the same, this connection is a clone
+                else:
+                    raise KeyError
         uow.pending_statements.append(stmt)
+
+    def track_cloned_connections(self, c, opt):
+        """
+        Track cloned connections from association tables.
+        """
+        if c not in self.units_of_work.keys():
+            for connection, uow in dict(self.units_of_work).items():
+                if connection.connection is c.connection:  # ConnectionFairy is the same - this is a clone
+                    self.units_of_work[c] = uow
 
     def track_association_operations(
         self, conn, cursor, statement, parameters, context, executemany

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -400,7 +400,8 @@ class VersioningManager(object):
         if op is not None:
             table_name = statement.split(' ')[2]
             table_names = [
-                table.name for table in self.association_tables
+                table.name if not table.schema else table.schema + '.' + table.name
+                for table in self.association_tables
             ]
             if table_name in table_names:
                 if executemany:

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -28,7 +28,7 @@ def tracked_operation(func):
                 uow = self.units_of_work[conn.engine]
             except KeyError:
                 for connection in self.units_of_work.keys():
-                    if connection.connection is conn.connection:
+                    if not connection.closed and connection.connection is conn.connection:
                         uow = self.unit_of_work(session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
@@ -374,7 +374,7 @@ class VersioningManager(object):
             del self.units_of_work[conn]
 
         for connection in dict(self.units_of_work).keys():
-            if conn.connection is connection.connection:
+            if connection.closed or conn.connection is connection.connection:
                 uow = self.units_of_work[connection]
                 uow.reset(session)
                 del self.units_of_work[connection]
@@ -396,7 +396,7 @@ class VersioningManager(object):
                 uow = self.units_of_work[conn.engine]
             except KeyError:
                 for connection in self.units_of_work.keys():
-                    if connection.connection is conn.connection:
+                    if not connection.closed and connection.connection is conn.connection:
                         uow = self.unit_of_work(conn.session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
@@ -409,7 +409,7 @@ class VersioningManager(object):
         """
         if c not in self.units_of_work.keys():
             for connection, uow in dict(self.units_of_work).items():
-                if connection.connection is c.connection:  # ConnectionFairy is the same - this is a clone
+                if not connection.closed and connection.connection is c.connection:  # ConnectionFairy is the same - this is a clone
                     self.units_of_work[c] = uow
 
     def track_association_operations(

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -379,6 +379,25 @@ class VersioningManager(object):
                 uow.reset(session)
                 del self.units_of_work[connection]
 
+    def clear_connection(self, conn):
+        if conn in self.units_of_work:
+            uow = self.units_of_work[conn]
+            uow.reset()
+            del self.units_of_work[conn]
+
+
+        for session, connection in dict(self.session_connection_map).items():
+            if connection is conn:
+                del self.session_connection_map[session]
+
+
+        for connection in dict(self.units_of_work).keys():
+            if connection.closed or conn.connection is connection.connection:
+                uow = self.units_of_work[connection]
+                uow.reset()
+                del self.units_of_work[connection]
+
+
     def append_association_operation(self, conn, table_name, params, op):
         """
         Append history association operation to pending_statements list.

--- a/sqlalchemy_continuum/manager.py
+++ b/sqlalchemy_continuum/manager.py
@@ -32,7 +32,7 @@ def tracked_operation(func):
                         uow = self.unit_of_work(session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
-                    raise KeyError
+                    raise
         return func(self, uow, target)
     return wrapper
 
@@ -400,7 +400,7 @@ class VersioningManager(object):
                         uow = self.unit_of_work(conn.session)
                         break  # The ConnectionFairy is the same, this connection is a clone
                 else:
-                    raise KeyError
+                    raise
         uow.pending_statements.append(stmt)
 
     def track_cloned_connections(self, c, opt):

--- a/sqlalchemy_continuum/model_builder.py
+++ b/sqlalchemy_continuum/model_builder.py
@@ -261,6 +261,7 @@ class ModelBuilder(object):
             name = '%sVersion' % (self.model.__name__,)
         return type(name, self.base_classes(), args)
 
+
     def __call__(self, table, tx_class):
         """
         Build history model and relationships to parent model, transaction

--- a/sqlalchemy_continuum/plugins/activity.py
+++ b/sqlalchemy_continuum/plugins/activity.py
@@ -191,6 +191,7 @@ target is the given article.
 
 import sqlalchemy as sa
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.inspection import inspect
 from sqlalchemy_utils import JSONType, generic_relationship
 
 from .base import Plugin
@@ -254,11 +255,13 @@ class ActivityFactory(ModelFactory):
                     if object_version:
                         return object_version.transaction_id
 
-                    version_cls = version_class(obj.__class__)
+                    model = obj.__class__
+                    version_cls = version_class(model)
+                    primary_key = inspect(model).primary_key[0].name
                     return session.query(
                         sa.func.max(version_cls.transaction_id)
                     ).filter(
-                        version_cls.id == obj.id
+                        getattr(version_cls, primary_key) == getattr(obj, primary_key)
                     ).scalar()
 
             def calculate_object_tx_id(self):

--- a/sqlalchemy_continuum/plugins/activity.py
+++ b/sqlalchemy_continuum/plugins/activity.py
@@ -314,6 +314,8 @@ class ActivityFactory(ModelFactory):
 
 
 class ActivityPlugin(Plugin):
+    activity_cls = None
+    
     def after_build_models(self, manager):
         self.activity_cls = ActivityFactory()(manager)
         manager.activity_cls = self.activity_cls

--- a/sqlalchemy_continuum/plugins/flask.py
+++ b/sqlalchemy_continuum/plugins/flask.py
@@ -36,7 +36,7 @@ def fetch_current_user_id():
     if _app_ctx_stack.top is None or _request_ctx_stack.top is None:
         return
     try:
-        return current_user.id
+        return current_user.get_id()
     except AttributeError:
         return
 

--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -316,7 +316,9 @@ class RelationshipBuilder(object):
             column.table
         )
         metadata = column.table.metadata
-        if metadata.schema:
+        if builder.parent_table.schema:
+            table_name = builder.parent_table.schema + '.' + builder.table_name
+        elif metadata.schema:
             table_name = metadata.schema + '.' + builder.table_name
         else:
             table_name = builder.table_name

--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -346,7 +346,10 @@ class RelationshipBuilder(object):
         except ClassNotVersioned:
             self.remote_cls = self.property.mapper.class_
 
-        if self.property.secondary is not None and not self.property.viewonly:
+        if (self.property.secondary is not None and
+                not self.property.viewonly and
+                not self.manager.is_excluded_property(
+                    self.model, self.property.key)):
             self.build_association_version_tables()
 
             # store remote cls to association table column pairs

--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -355,7 +355,7 @@ class RelationshipBuilder(object):
             # store remote cls to association table column pairs
             self.remote_to_association_column_pairs = []
             for column_pair in self.property.local_remote_pairs:
-                if column_pair[0] in self.property.table.c.values():
+                if column_pair[0] in self.property.target.c.values():
                     self.remote_to_association_column_pairs.append(column_pair)
 
         setattr(

--- a/sqlalchemy_continuum/relationship_builder.py
+++ b/sqlalchemy_continuum/relationship_builder.py
@@ -249,6 +249,7 @@ class RelationshipBuilder(object):
                 FROM article_tag_version as article_tag_version2
                 WHERE article_tag_version2.tag_id = article_tag_version.tag_id
                 AND article_tag_version2.tx_id <=5
+                AND article_tag_version2.article_id = 3
                 GROUP BY article_tag_version2.tag_id
                 HAVING
                     MAX(article_tag_version2.tx_id) =
@@ -260,6 +261,8 @@ class RelationshipBuilder(object):
         """
 
         tx_column = option(obj, 'transaction_column_name')
+        join_column = self.property.primaryjoin.right.name
+        object_join_column = self.property.primaryjoin.left.name
         reflector = VersionExpressionReflector(obj, self.property)
 
         association_table_alias = self.association_version_table.alias()
@@ -276,6 +279,7 @@ class RelationshipBuilder(object):
                 sa.and_(
                     association_table_alias.c[tx_column] <=
                     getattr(obj, tx_column),
+                    association_table_alias.c[join_column] == getattr(obj, object_join_column),
                     *[association_col ==
                       self.association_version_table.c[association_col.name]
                       for association_col

--- a/sqlalchemy_continuum/table_builder.py
+++ b/sqlalchemy_continuum/table_builder.py
@@ -150,5 +150,6 @@ class TableBuilder(object):
             extends.name if extends is not None else self.table_name,
             self.parent_table.metadata,
             *columns,
+            schema=self.parent_table.schema,
             extend_existing=extends is not None
         )

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -147,9 +147,7 @@ class TransactionFactory(ModelFactory):
 
                 user_id = sa.Column(
                     sa.inspect(user_cls).primary_key[0].type,
-                    sa.ForeignKey(
-                        '%s.%s' % (user_cls.__tablename__, sa.inspect(user_cls).primary_key[0].name)
-                    ),
+                    sa.ForeignKey(sa.inspect(user_cls).primary_key[0]),
                     index=True
                 )
 

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -23,6 +23,10 @@ def compile_big_integer(element, compiler, **kw):
     return 'INTEGER'
 
 
+class NoChangesColumn(Exception):
+    pass
+
+
 class TransactionBase(object):
     issued_at = sa.Column(sa.DateTime, default=datetime.utcnow)
 
@@ -30,8 +34,13 @@ class TransactionBase(object):
     def entity_names(self):
         """
         Return a list of entity names that changed during this transaction.
+        Raises a NoChangesColumn exception if the 'changes' column does
+        not exist, most likely because TransactionChangesPlugin is not enabled.
         """
-        return [changes.entity_name for changes in self.changes]
+        if 'changes' in self.__table__.columns:
+          return [changes.entity_name for changes in self.changes]
+        else:
+          raise NoChangesColumn()
 
     @property
     def changed_entities(self):
@@ -48,8 +57,11 @@ class TransactionBase(object):
         session = sa.orm.object_session(self)
 
         for class_, version_class in tuples:
-            if class_.__name__ not in self.entity_names:
-                continue
+            try:
+                if class_.__name__ not in self.entity_names:
+                    continue
+            except NoChangesColumn:
+                pass
 
             tx_column = manager.option(class_, 'transaction_column_name')
 

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -23,7 +23,7 @@ def compile_big_integer(element, compiler, **kw):
     return 'INTEGER'
 
 
-class NoChangesColumn(Exception):
+class NoChangesAttribute(Exception):
     pass
 
 
@@ -34,13 +34,13 @@ class TransactionBase(object):
     def entity_names(self):
         """
         Return a list of entity names that changed during this transaction.
-        Raises a NoChangesColumn exception if the 'changes' column does
+        Raises a NoChangesAttribute exception if the 'changes' column does
         not exist, most likely because TransactionChangesPlugin is not enabled.
         """
         if hasattr(self, 'changes'):
           return [changes.entity_name for changes in self.changes]
         else:
-          raise NoChangesColumn()
+          raise NoChangesAttribute()
 
     @property
     def changed_entities(self):
@@ -60,7 +60,7 @@ class TransactionBase(object):
             try:
                 if class_.__name__ not in self.entity_names:
                     continue
-            except NoChangesColumn:
+            except NoChangesAttribute:
                 pass
 
             tx_column = manager.option(class_, 'transaction_column_name')

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -132,7 +132,11 @@ class TransactionFactory(ModelFactory):
 
             if manager.user_cls:
                 user_cls = manager.user_cls
-                registry = manager.declarative_base._decl_class_registry
+                Base = manager.declarative_base
+                try:
+                    registry = Base.registry._class_registry
+                except AttributeError:  # SQLAlchemy < 1.4
+                    registry = Base._decl_class_registry
 
                 if isinstance(user_cls, six.string_types):
                     try:

--- a/sqlalchemy_continuum/transaction.py
+++ b/sqlalchemy_continuum/transaction.py
@@ -37,7 +37,7 @@ class TransactionBase(object):
         Raises a NoChangesColumn exception if the 'changes' column does
         not exist, most likely because TransactionChangesPlugin is not enabled.
         """
-        if 'changes' in self.__table__.columns:
+        if hasattr(self, 'changes'):
           return [changes.entity_name for changes in self.changes]
         else:
           raise NoChangesColumn()

--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -252,7 +252,7 @@ class UnitOfWork(object):
                     parent,
                     version_obj,
                     alias=sa.orm.aliased(class_.__table__)
-                )
+                ).scalar_subquery()
                 query = (
                     session.query(class_.__table__)
                     .filter(

--- a/sqlalchemy_continuum/unit_of_work.py
+++ b/sqlalchemy_continuum/unit_of_work.py
@@ -252,7 +252,12 @@ class UnitOfWork(object):
                     parent,
                     version_obj,
                     alias=sa.orm.aliased(class_.__table__)
-                ).scalar_subquery()
+                )
+                try:
+                    subquery = subquery.scalar_subquery()
+                except AttributeError:  # SQLAlchemy < 1.4
+                    subquery = subquery.as_scalar()
+
                 query = (
                     session.query(class_.__table__)
                     .filter(

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -202,7 +202,11 @@ def versioned_column_properties(obj_or_class):
     cls = obj_or_class if isclass(obj_or_class) else obj_or_class.__class__
 
     mapper = sa.inspect(cls)
-    for key in mapper.columns.keys():
+    for key, column in mapper.columns.items():
+        # Ignores non table columns
+        if not isinstance(column, sa.Column):
+            continue
+
         if not manager.is_excluded_property(obj_or_class, key):
             yield getattr(mapper.attrs, key)
 

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -133,7 +133,11 @@ def version_table(table):
 
     :param table: SQLAlchemy Table object
     """
-    if table.metadata.schema:
+    if table.schema:
+        return table.metadata.tables[
+            table.schema + '.' + table.name + '_version'
+        ]
+    elif table.metadata.schema:
         return table.metadata.tables[
             table.metadata.schema + '.' + table.name + '_version'
         ]

--- a/sqlalchemy_continuum/utils.py
+++ b/sqlalchemy_continuum/utils.py
@@ -215,7 +215,7 @@ def versioned_relationships(obj, versioned_column_keys):
             yield prop
 
 
-def vacuum(session, model):
+def vacuum(session, model, yield_per=1000):
     """
     When making structural changes to version tables (for example dropping
     columns) there are sometimes situations where some old version records
@@ -236,6 +236,7 @@ def vacuum(session, model):
 
     :param session: SQLAlchemy session object
     :param model: SQLAlchemy declarative model class
+    :param yield_per: how many rows to process at a time
     """
     version_cls = version_class(model)
     versions = defaultdict(list)
@@ -243,15 +244,18 @@ def vacuum(session, model):
     query = (
         session.query(version_cls)
         .order_by(option(version_cls, 'transaction_column_name'))
-    )
+    ).yield_per(yield_per)
+
+    primary_key_col = sa.inspection.inspect(model).primary_key[0].name
 
     for version in query:
-        if versions[version.id]:
-            prev_version = versions[version.id][-1]
+        version_id = getattr(version, primary_key_col)
+        if versions[version_id]:
+            prev_version = versions[version_id][-1]
             if naturally_equivalent(prev_version, version):
                 session.delete(version)
         else:
-            versions[version.id].append(version)
+            versions[version_id].append(version)
 
 
 def is_internal_column(model, column_name):

--- a/sqlalchemy_continuum/version.py
+++ b/sqlalchemy_continuum/version.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+
 from .reverter import Reverter
 from .utils import get_versioning_manager, is_internal_column, parent_class
 
@@ -49,9 +50,6 @@ class VersionClassBase(object):
         and second list value as the new value.
         """
         previous_version = self.previous
-        if not previous_version and self.operation_type != 0:
-            return {}
-
         data = {}
 
         for key in sa.inspect(self.__class__).columns.keys():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,9 +42,9 @@ def log_sql(
 
 def get_dns_from_driver(driver):
     if driver == 'postgres':
-        return 'postgres://postgres@localhost/sqlalchemy_continuum_test'
+        return 'postgresql://postgres:postgres@localhost/sqlalchemy_continuum_test'
     elif driver == 'mysql':
-        return 'mysql+pymysql://travis@localhost/sqlalchemy_continuum_test'
+        return 'mysql+pymysql://root@localhost/sqlalchemy_continuum_test'
     elif driver == 'sqlite':
         return 'sqlite:///:memory:'
     else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+
 from copy import copy
 import inspect
 import itertools as it
@@ -6,7 +7,7 @@ import warnings
 import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, column_property
 from sqlalchemy_continuum import (
     ClassNotVersioned,
     version_class,
@@ -147,6 +148,9 @@ class TestCase(object):
             name = sa.Column(sa.Unicode(255), nullable=False)
             content = sa.Column(sa.UnicodeText)
             description = sa.Column(sa.UnicodeText)
+
+            # Dynamic column cotaining all text content data
+            fulltext_content = column_property(name + content + description)
 
         class Tag(self.Model):
             __tablename__ = 'tag'

--- a/tests/inheritance/test_single_table_inheritance.py
+++ b/tests/inheritance/test_single_table_inheritance.py
@@ -19,6 +19,7 @@ class SingleTableInheritanceTestCase(TestCase):
 
             __mapper_args__ = {
                 'polymorphic_on': discriminator,
+                'polymorphic_identity': u'base',
                 'with_polymorphic': '*'
             }
 

--- a/tests/inheritance/test_single_table_inheritance.py
+++ b/tests/inheritance/test_single_table_inheritance.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy_continuum import versioning_manager, version_class
 from tests import TestCase, create_test_cases
 
@@ -24,6 +25,10 @@ class SingleTableInheritanceTestCase(TestCase):
         class Article(TextItem):
             __mapper_args__ = {'polymorphic_identity': u'article'}
             name = sa.Column(sa.Unicode(255))
+
+            @sa.ext.declarative.declared_attr
+            def status(cls):
+                return sa.Column("_status", sa.Unicode(255))
 
         class BlogPost(TextItem):
             __mapper_args__ = {'polymorphic_identity': u'blog_post'}
@@ -78,6 +83,9 @@ class SingleTableInheritanceTestCase(TestCase):
         ).first()
         assert transaction.entity_names == [u'Article']
         assert transaction.changed_entities
+
+    def test_declared_attr_inheritance(self):
+        assert self.ArticleVersion.status
 
 
 create_test_cases(SingleTableInheritanceTestCase)

--- a/tests/plugins/test_activity.py
+++ b/tests/plugins/test_activity.py
@@ -52,7 +52,7 @@ class TestActivityNotId(ActivityTestCase):
         self.NotIdModel = NotIdModel
 
     def test_create_activity_with_pk(self):
-        not_id_model = self.NotIdModel(name="abc")
+        not_id_model = self.NotIdModel(name=u'Some model without id PK')
         self.session.add(not_id_model)
         self.session.commit()
         self.create_activity(not_id_model)

--- a/tests/plugins/test_activity.py
+++ b/tests/plugins/test_activity.py
@@ -36,6 +36,34 @@ class ActivityTestCase(TestCase):
         return activity
 
 
+class TestActivityNotId(ActivityTestCase):
+
+    def create_models(self):
+        TestCase.create_models(self)
+
+        class NotIdModel(self.Model):
+            __tablename__ = 'not_id'
+            __versioned__ = {
+                'base_classes': (self.Model, )
+            }
+
+            pk = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255), nullable=False)
+        self.NotIdModel = NotIdModel
+
+    def test_create_activity_with_pk(self):
+        not_id_model = self.NotIdModel(name="abc")
+        self.session.add(not_id_model)
+        self.session.commit()
+        self.create_activity(not_id_model)
+        self.session.commit()
+        activity = self.session.query(versioning_manager.activity_cls).first()
+        assert activity
+        assert activity.transaction_id
+        assert activity.object == not_id_model
+        assert activity.object_version == not_id_model.versions[-1]
+
+
 class TestActivity(ActivityTestCase):
     def test_creates_activity_class(self):
         assert versioning_manager.activity_cls.__name__ == 'Activity'

--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import Flask, url_for
-from flask_login import LoginManager
+from flask_login import LoginManager, UserMixin
 from flask_sqlalchemy import SQLAlchemy, _SessionSignalEvents
 from flexmock import flexmock
 
@@ -76,7 +76,7 @@ class TestFlaskPlugin(TestCase):
     def create_models(self):
         TestCase.create_models(self)
 
-        class User(self.Model):
+        class User(self.Model, UserMixin):
             __tablename__ = 'user'
             __versioned__ = {
                 'base_classes': (self.Model, )

--- a/tests/plugins/test_flask.py
+++ b/tests/plugins/test_flask.py
@@ -66,12 +66,12 @@ class TestFlaskPlugin(TestCase):
         :returns: the logged in user
         """
         with self.client.session_transaction() as s:
-            s['user_id'] = user.id
+            s['_user_id'] = user.id
         return user
 
     def logout(self, user=None):
         with self.client.session_transaction() as s:
-            s['user_id'] = None
+            s['_user_id'] = None
 
     def create_models(self):
         TestCase.create_models(self)
@@ -281,5 +281,3 @@ class TestFlaskPluginWithFlaskSQLAlchemyExtension(object):
         uow = versioning_manager.unit_of_work(self.db.session)
         transaction = uow.create_transaction(self.db.session)
         assert transaction.id
-
-

--- a/tests/relationships/test_association_table_relations.py
+++ b/tests/relationships/test_association_table_relations.py
@@ -1,0 +1,61 @@
+import sqlalchemy as sa
+from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy.orm import relationship
+from tests import TestCase, create_test_cases
+
+
+class AssociationTableRelationshipsTestCase(TestCase):
+    def create_models(self):
+        super(AssociationTableRelationshipsTestCase, self).create_models()
+
+        class PublishedArticle(self.Model):
+            __tablename__ = 'published_article'
+            __table_args__ = (
+                PrimaryKeyConstraint("article_id", "author_id"),
+                {'useexisting': True}
+            )
+
+            article_id = sa.Column(sa.Integer, sa.ForeignKey('article.id'))
+            author_id = sa.Column(sa.Integer, sa.ForeignKey('author.id'))
+            author = relationship('Author')
+            article = relationship('Article')
+
+        self.PublishedArticle = PublishedArticle
+
+        published_articles_table = sa.Table(PublishedArticle.__tablename__,
+                                            PublishedArticle.metadata,
+                                            extend_existing=True)
+
+        class Author(self.Model):
+            __tablename__ = 'author'
+            __versioned__ = {
+                'base_classes': (self.Model, )
+            }
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+            articles = relationship('Article', secondary=published_articles_table)
+
+        self.Author = Author
+
+    def test_version_relations(self):
+        article = self.Article()
+        name = u'Some article'
+        article.name = name
+        article.content = u'Some content'
+        self.session.add(article)
+        self.session.commit()
+        assert article.versions[0].name == name
+
+        au = self.Author(name=u'Some author')
+        self.session.add(au)
+        self.session.commit()
+
+        pa = self.PublishedArticle(article_id=article.id, author_id=au.id)
+        self.session.add(pa)
+
+        self.session.commit()
+
+
+
+create_test_cases(AssociationTableRelationshipsTestCase)

--- a/tests/relationships/test_association_table_relations.py
+++ b/tests/relationships/test_association_table_relations.py
@@ -12,7 +12,7 @@ class AssociationTableRelationshipsTestCase(TestCase):
             __tablename__ = 'published_article'
             __table_args__ = (
                 PrimaryKeyConstraint("article_id", "author_id"),
-                {'useexisting': True}
+                {'keep_existing': True}
             )
 
             article_id = sa.Column(sa.Integer, sa.ForeignKey('article.id'))

--- a/tests/relationships/test_many_to_many_relations.py
+++ b/tests/relationships/test_many_to_many_relations.py
@@ -70,6 +70,33 @@ class ManyToManyRelationshipsTestCase(TestCase):
         self.session.commit()
         assert len(article.versions[0].tags) == 1
 
+    def test_unrelated_change(self):
+        tag1 = self.Tag(name=u'some tag')
+        tag2 = self.Tag(name=u'some tag2')
+
+        self.session.add(tag1)
+        self.session.add(tag2)
+        self.session.commit()
+
+        article1 = self.Article(name="Some article", )
+        article1.name = u'Some article'
+        article1.tags.append(tag1)
+
+        self.session.add(article1)
+        self.session.commit()
+
+        article2 = self.Article()
+        article2.name = u'Some article2'
+        article2.tags.append(tag1)
+
+        self.session.add(article2)
+        self.session.commit()
+
+        article1.name = u'Some other name'
+        self.session.commit()
+
+        assert len(article1.versions[1].tags) == 1
+
     def test_multi_insert(self):
         article = self.Article()
         article.name = u'Some article'

--- a/tests/test_changeset.py
+++ b/tests/test_changeset.py
@@ -55,7 +55,11 @@ class ChangeSetTestCase(ChangeSetBaseTestCase):
             ''' % (self.transaction_column_name, tx_log.id)
         )
 
-        assert self.session.query(self.ArticleVersion).first().changeset == {}
+        assert self.session.query(self.ArticleVersion).first().changeset == {
+            'content': [None, 'some content'],
+            'id': [None, 1],
+            'name': [None, 'something']
+        }
 
 
 class TestChangeSetWithValidityStrategy(ChangeSetTestCase):
@@ -71,7 +75,7 @@ class TestChangeSetWhenParentContainsAdditionalColumns(ChangeSetTestCase):
         class Article(self.Model):
             __tablename__ = 'article'
             __versioned__ = {
-                'base_classes': (self.Model, )
+                'base_classes': (self.Model,)
             }
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -82,7 +86,7 @@ class TestChangeSetWhenParentContainsAdditionalColumns(ChangeSetTestCase):
         class Tag(self.Model):
             __tablename__ = 'tag'
             __versioned__ = {
-                'base_classes': (self.Model, )
+                'base_classes': (self.Model,)
             }
 
             id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
@@ -92,8 +96,8 @@ class TestChangeSetWhenParentContainsAdditionalColumns(ChangeSetTestCase):
 
         Article.tag_count = sa.orm.column_property(
             sa.select([sa.func.count(Tag.id)])
-            .where(Tag.article_id == Article.id)
-            .correlate_except(Tag)
+                .where(Tag.article_id == Article.id)
+                .correlate_except(Tag)
         )
 
         self.Article = Article

--- a/tests/test_column_inclusion_and_exclusion.py
+++ b/tests/test_column_inclusion_and_exclusion.py
@@ -53,3 +53,52 @@ class TestColumnExclusionWithAliasedColumn(ColumnExclusionTestCase):
             content = sa.Column('_content', sa.UnicodeText)
 
         self.TextItem = TextItem
+
+
+class TestColumnExclusionWithRelationship(TestCase):
+    def create_models(self):
+
+        class Word(self.Model):
+            __tablename__ = 'word'
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            word = sa.Column(sa.Unicode(255))
+
+        class TextItemWord(self.Model):
+            __tablename__ = 'text_item_word'
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            text_item_id = sa.Column(sa.Integer, sa.ForeignKey('text_item.id'), nullable=False)
+            word_id = sa.Column(sa.Integer, sa.ForeignKey('word.id'), nullable=False)
+
+        class TextItem(self.Model):
+            __tablename__ = 'text_item'
+            __versioned__ = {
+                'exclude': ['content']
+            }
+
+            id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+            name = sa.Column(sa.Unicode(255))
+            content = sa.orm.relationship(Word, secondary='text_item_word')
+
+        self.TextItem = TextItem
+        self.Word = Word
+
+    def test_excluded_columns_not_included_in_version_class(self):
+        cls = version_class(self.TextItem)
+        manager = cls._sa_class_manager
+        assert 'content' not in manager.keys()
+
+    def test_versioning_with_column_exclusion(self):
+        item = self.TextItem(name=u'Some textitem',
+                             content=[self.Word(word=u'bird')])
+        self.session.add(item)
+        self.session.commit()
+
+        assert item.versions[0].name == u'Some textitem'
+
+    def test_does_not_create_record_if_only_excluded_column_updated(self):
+        item = self.TextItem(name=u'Some textitem')
+        self.session.add(item)
+        self.session.commit()
+        item.content.append(self.Word(word=u'Some content'))
+        self.session.commit()
+        assert item.versions.count() == 1

--- a/tests/test_mapper_args.py
+++ b/tests/test_mapper_args.py
@@ -1,3 +1,6 @@
+from pytest import mark
+from packaging import version
+
 import sqlalchemy as sa
 from sqlalchemy_continuum import version_class
 from tests import TestCase
@@ -29,6 +32,7 @@ class TestColumnPrefix(TestCase):
         assert self.TextItem._id
 
 
+@mark.skipif("version.parse(sa.__version__) >= version.parse('1.4')")
 class TestOrderByWithStringArg(TestCase):
     def create_models(self):
         class TextItem(self.Model):
@@ -55,6 +59,7 @@ class TestOrderByWithStringArg(TestCase):
         assert self.TextItemVersion.__mapper_args__['order_by'] == 'id'
 
 
+@mark.skipif("version.parse(sa.__version__) >= version.parse('1.4')")
 class TestOrderByWithInstrumentedAttribute(TestCase):
     def create_models(self):
         class TextItem(self.Model):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -52,3 +52,19 @@ class TestUnitOfWork(TestCase):
     def test_with_session_arg(self):
         uow = versioning_manager.unit_of_work(self.session)
         assert isinstance(uow, UnitOfWork)
+
+
+class TestExternalTransactionSession(TestCase):
+
+    def test_session_with_external_transaction(self):
+        conn = self.engine.connect()
+        t = conn.begin()
+        session = Session(bind=conn)
+
+        article = self.Article(name=u'My Session Article')
+        session.add(article)
+        session.flush()
+
+        session.close()
+        t.rollback()
+        conn.close()

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy_continuum import versioning_manager
 from tests import TestCase
+from pytest import mark
 
 
 class TestTransaction(TestCase):
@@ -56,3 +57,31 @@ class TestAssigningUserClass(TestCase):
     def test_copies_primary_key_type_from_user_class(self):
         attr = versioning_manager.transaction_cls.user_id
         assert isinstance(attr.property.columns[0].type, sa.Unicode)
+
+
+@mark.skipif("os.environ.get('DB') == 'sqlite'")
+class TestAssigningUserClassInOtherSchema(TestCase):
+    user_cls = 'User'
+
+    def create_models(self):
+        class User(self.Model):
+            __tablename__ = 'user'
+            __versioned__ = {
+                    'base_classes': (self.Model,)
+            }
+            __table_args__ = {'schema': 'other'}
+
+            id = sa.Column(sa.Unicode(255), primary_key=True)
+            name = sa.Column(sa.Unicode(255), nullable=False)
+
+        self.User = User
+
+    def create_tables(self):
+        self.connection.execute('DROP SCHEMA IF EXISTS other')
+        self.connection.execute('CREATE SCHEMA other')
+        TestCase.create_tables(self)
+
+    def test_can_build_transaction_model(self):
+        # If create_models didn't crash this should be good
+        pass
+

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -2,6 +2,8 @@ import sqlalchemy as sa
 from sqlalchemy_continuum import versioning_manager
 from tests import TestCase
 from pytest import mark
+from sqlalchemy_continuum.plugins import TransactionMetaPlugin
+
 
 
 class TestTransaction(TestCase):
@@ -37,6 +39,19 @@ class TestTransaction(TestCase):
             ) ==
             repr(transaction)
         )
+
+    def test_changed_entities(self):
+        article_v0 = self.article.versions[0]
+        transaction = article_v0.transaction
+        assert transaction.changed_entities == {
+            self.ArticleVersion: [article_v0],
+            self.TagVersion: [self.article.tags[0].versions[0]],
+        }
+
+
+# Check that the tests pass without TransactionChangesPlugin
+class TestTransactionWithoutChangesPlugin(TestTransaction):
+    plugins = [TransactionMetaPlugin()]
 
 
 class TestAssigningUserClass(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35
+envlist = py27, py33, py34, py35, py36, py37
 
 [testenv]
 commands = pip install -e ".[test]"


### PR DESCRIPTION
In order to update our `SQLAlchemy` package in `spark`, `sqlalchemy-continuum`  needs to be upgraded. This PR follows the steps in this [Syncing A Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) doc to get the latest code from `sqlalchemy-continuum` into our version of it.